### PR TITLE
Remove owner parameter from ami resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,15 +285,9 @@ ${hostedzone://example.com/public}
 ${hostedzone://example.com/private}
 ```
 ### AMI Lookup
-<<<<<<< HEAD
 
-Looks up an AMI given a name prefix which may contain wildcards. If query returns multiple images the latest is used.
+Looks up an AMI given a name which may contain wildcards. If query returns multiple images the latest is used.
 
-=======
-
-Looks up an AMI given a name prefix which may contain wildcards. If query returns multiple images the latest is used.
-
->>>>>>> 602b53605d723635b6eab2cd2711685bd46c454e
 ```bash
 ${ami://amzn-ami-hv*x86_64-gp2?owner=amazon}
 ${ami://my-windows-soe}

--- a/spec/resolver/ami_spec.rb
+++ b/spec/resolver/ami_spec.rb
@@ -18,21 +18,14 @@ describe Bora::Resolver::Ami do
     ec2
   end
 
-  it "returns the latest image from the 'self' account" do
+  it "returns the latest image available" do
     expect(ec2).to receive(:describe_images)
-      .with(describe_images_request("my_ami_*", "self"))
+      .with(describe_images_request("my_ami_*"))
       .and_return(describe_images_response)
 
     expect(resolver.resolve(URI("ami://my_ami_*"))).to eq("ami-2")
   end
 
-  it "returns the latest image from the specified account" do
-    expect(ec2).to receive(:describe_images)
-      .with(describe_images_request("my_ami_*", "amazon"))
-      .and_return(describe_images_response)
-
-    expect(resolver.resolve(URI("ami://my_ami_*?owner=amazon"))).to eq("ami-2")
-  end
 
   it "raises an exception if no ami is found" do
     expect(ec2).to receive(:describe_images).and_return(OpenStruct.new(images: []))
@@ -44,9 +37,8 @@ describe Bora::Resolver::Ami do
   end
 
 
-  def describe_images_request(ami, owner)
+  def describe_images_request(ami)
     {
-      owners: [owner],
       filters: [
         { name: "name", values: [ami] },
         { name:   'state', values: ['available'] }


### PR DESCRIPTION
Howdy,

My team pointed out that the ami resolver doesn't quite work for us with our multiple AWS account structure with AMI's shared between accounts.. After a bit more of a careful read of the describe_images doco 

`Omitting this option returns all images for which you have launch permissions, regardless of ownership.`

I don't think it's needed.
