### PR TITLE
Support inline ruby in yaml config file

### DIFF
--- a/lib/bora.rb
+++ b/lib/bora.rb
@@ -40,7 +40,7 @@ class Bora
 
   def load_config(config)
     if config.class == String
-      YAML.load_file(config)
+      YAML.load(ERB.new(File.read(config)).result)
     elsif config.class == Hash
       config
     end


### PR DESCRIPTION
My use case was to use `ENV['var']` in the `bora.yml` so I made this small PR for it.
