### PR TITLE
Increase default retry_limit

### DIFF
--- a/lib/bora/cfn/stack.rb
+++ b/lib/bora/cfn/stack.rb
@@ -112,7 +112,12 @@ class Bora
 
       def cloudformation
         @cfn ||= begin
-          @region ? Aws::CloudFormation::Client.new(region: @region) : Aws::CloudFormation::Client.new
+          options = {
+            retry_limit: 10,
+            retry_backoff: proc { |attempts| sleep(2**attempts) }
+          }
+          options['region'] = @region if @region
+          Aws::CloudFormation::Client.new options
         end
       end
 

--- a/lib/bora/cfn/stack.rb
+++ b/lib/bora/cfn/stack.rb
@@ -112,12 +112,9 @@ class Bora
 
       def cloudformation
         @cfn ||= begin
-          options = {
-            retry_limit: 10,
-            retry_backoff: proc { |attempts| sleep(2**attempts) }
-          }
-          options['region'] = @region if @region
-          Aws::CloudFormation::Client.new options
+          options = { retry_limit: 10 }
+          options[:region] = @region if @region
+          Aws::CloudFormation::Client.new(options)
         end
       end
 


### PR DESCRIPTION
We've been getting the occasional
` Rate exceeded (Aws::CloudFormation::Errors::Throttling)`
for stacks with a lot of cfn:// resolvers. 

This ups the default retry to 10 (possibly should be configurable).

Retry backoff is handled by Aws::Plugins::RetryErrors
http://docs.aws.amazon.com/sdkforruby/api/Aws/Plugins/RetryErrors.html